### PR TITLE
MANIFEST.in recursive-include mlconjug *

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,8 @@ include README.rst
 include INSTALL.rst
 
 recursive-include tests *
+recursive-include mlconjug *
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 


### PR DESCRIPTION
ISSUE:
    >>> import mlconjug
    >>> default_conjugator = mlconjug.Conjugator(language='es')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/local/lib/python3.6/dist-packages/mlconjug/mlconjug.py", line 127, in __init__
        self.conjug_manager = ConjugManager(language=language)
      File "/usr/local/lib/python3.6/dist-packages/mlconjug/PyVerbiste.py", line 117, in __init__
        self._load_verbs(verbs_file)
      File "/usr/local/lib/python3.6/dist-packages/mlconjug/PyVerbiste.py", line 136, in _load_verbs
        with open(verbs_file, 'r', encoding='utf-8') as file:
    FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.6/dist-packages/mlconjug/data/conjug_manager/verbs-es.json'
    >>>


FIX:
    1.  ./MANIFEST.in
            recursive-include mlconjug *